### PR TITLE
Update gargle app

### DIFF
--- a/R/registry.R
+++ b/R/registry.R
@@ -9,7 +9,7 @@
 #'
 #' @format An environment.
 #' @keywords internal
-gargle_env <- new.env()
+gargle_env <- new.env(parent = emptyenv())
 gargle_env$credential_functions <- list()
 
 #' Check that f is a viable credential fetching function.

--- a/R/three-legged-oauth.R
+++ b/R/three-legged-oauth.R
@@ -5,12 +5,16 @@
 #' @param ... Additional arguments (ignored)
 #' @export
 get_user_oauth2_credentials <- function(scopes, oauth_app = NULL, ...) {
-  
-  endpoint <- httr::oauth_endpoints("google")
-  app <- httr::oauth_app("google",
-                         "465736758727.apps.googleusercontent.com",
-                         "fJbIIyoIag0oA6p114lwsV2r")
-  token <- httr::oauth2.0_token(endpoint = endpoint, app = app, scope = scopes,
-                                  use_oob = FALSE)
+
+  app <- httr::oauth_app(
+    "google",
+    key = "603366585132-nku3fbd298ma3925l12o2hq0cc1v8u11.apps.googleusercontent.com",
+    secret = "as_N12yfWLRL9RMz5nVpgCZt"
+  )
+  token <- httr::oauth2.0_token(
+    endpoint = httr::oauth_endpoints("google"),
+    app = app,
+    scope = scopes
+  )
   token
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,11 @@
+comment: false
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 10%
+    patch:
+      default:
+        target: auto
+        threshold: 10%


### PR DESCRIPTION
This is the gargle client id and secret now FYI. Only Drive and Sheets APIs currently enabled, see #5