### PR TITLE
Refactor cache

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,11 +14,12 @@ Description: Utilities to take some of the pain out of dealing with
     their users.
 License: MIT + file LICENSE
 LazyData: true
-Imports:
+Imports: 
     debugme,
     httr,
     jsonlite,
-    magrittr
+    magrittr,
+    tibble
 Suggests:
     testthat
 RoxygenNote: 6.0.1.9000

--- a/R/Gargle-class.R
+++ b/R/Gargle-class.R
@@ -22,10 +22,10 @@ gargle2.0_token <- function(email = NULL,
                             scope = NULL,
                             user_params = NULL,
                             type = NULL,
-                            use_oob = getOption("httr_oob_default"),
+                            use_oob = getOption("gargle.oob_default"),
                             ## params end
                             credentials = NULL,
-                            cache = getOption("httr_oauth_cache"), ...) {
+                            cache = getOption("gargle.oauth_cache"), ...) {
   params <- list(
     scope = scope,
     user_params = user_params,
@@ -67,7 +67,7 @@ Gargle2.0 <- R6::R6Class("Gargle2.0", inherit = httr::Token2.0, list(
                         app = gargle_app(),
                         credentials = NULL,
                         params = list(),
-                        cache_path = getOption("httr_oauth_cache")) {
+                        cache_path = getOption("gargle.oauth_cache")) {
     "!DEBUG Gargle2.0 initialize"
     stopifnot(
       httr:::is.oauth_endpoint(endpoint) || !is.null(credentials),

--- a/R/Gargle-class.R
+++ b/R/Gargle-class.R
@@ -70,8 +70,8 @@ Gargle2.0 <- R6::R6Class("Gargle2.0", inherit = httr::Token2.0, list(
                         cache_path = getOption("gargle.oauth_cache")) {
     "!DEBUG Gargle2.0 initialize"
     stopifnot(
-      httr:::is.oauth_endpoint(endpoint) || !is.null(credentials),
-      httr:::is.oauth_app(app),
+      is.oauth_endpoint(endpoint) || !is.null(credentials),
+      is.oauth_app(app),
       is.list(params)
     )
 
@@ -80,7 +80,7 @@ Gargle2.0 <- R6::R6Class("Gargle2.0", inherit = httr::Token2.0, list(
     self$endpoint <- endpoint
     params$scope <- add_email_scope(params$scope)
     self$params <- params
-    self$cache_path <- httr:::use_cache(cache_path)
+    self$cache_path <- use_cache(cache_path)
 
     if (!is.null(credentials)) {
       # Use credentials created elsewhere - usually for tests
@@ -149,7 +149,7 @@ Gargle2.0 <- R6::R6Class("Gargle2.0", inherit = httr::Token2.0, list(
       cached <- fetch_matching_tokens(self$hash(), self$cache_path)
     } else {
       "!DEBUG searching cache for matches on endpoint + app + scopes + email: `sQuote(self$email)`"
-      cached <- httr:::fetch_cached_token(self$hash(), self$cache_path)
+      cached <- fetch_cached_token(self$hash(), self$cache_path)
     }
 
     if (is.null(cached)) return(FALSE)
@@ -165,7 +165,8 @@ Gargle2.0 <- R6::R6Class("Gargle2.0", inherit = httr::Token2.0, list(
 fetch_matching_tokens <- function(hash, cache_path) {
   if (is.null(cache_path)) return(NULL)
 
-  tokens <- httr:::load_cache(cache_path)
+  "!DEBUG `cache_path`"
+  tokens <- load_cache(cache_path)
   matches <- mask_email(names(tokens)) == mask_email(hash)
 
   if (!any(matches)) return(NULL)

--- a/R/oauth-cache.R
+++ b/R/oauth-cache.R
@@ -1,0 +1,117 @@
+## see oauth-cache.R in httr
+## nothing there is exported, so to make desired changes to oauth caching
+## I have to copy and mutate here
+
+gargle_cache_path <- function() {
+  "~/.R/gargle/gargle-oauth"
+}
+
+use_cache <- function(cache = getOption("gargle.oauth_cache")) {
+  if (length(cache) != 1) {
+    stop("cache should be length 1 vector", call. = FALSE)
+  }
+  if (!is.logical(cache) && !is.character(cache)) {
+    stop("Cache must either be logical or string (file path)")
+  }
+
+  # If missing, see if it's ok to use one, and cache the results of
+  # that check in a global option.
+  if (is.na(cache)) {
+    cache <- can_use_cache()
+    options("gargle.oauth_cache" = cache)
+  }
+  ## cache is now TRUE, FALSE or path
+
+  if (isFALSE(cache)) {
+    return(NULL)
+  }
+
+  if (isTRUE(cache)) {
+    cache <- gargle_cache_path()
+  }
+
+  if (!file.exists(cache)) {
+    create_cache(cache)
+  }
+  return(cache)
+}
+
+can_use_cache <- function(path = gargle_cache_path()) {
+  file.exists(path) || should_cache(path)
+}
+
+should_cache <- function(path = gargle_cache_path()) {
+  if (!interactive()) return(FALSE)
+
+  cat("Use a local file ('", path, "'), to cache OAuth access credentials ",
+      "between R sessions?\n", sep = "")
+  utils::menu(c("Yes", "No")) == 1
+}
+
+create_cache <- function(path = gargle_cache_path()) {
+
+  cache_parent <- dirname(path)
+  if (!dir.exists(cache_parent)) {
+    dir.create(cache_parent, recursive = TRUE)
+  }
+
+  file.create(path, showWarnings = FALSE)
+  if (!file.exists(path)) {
+    stop("Failed to create local cache ('", path, "')", call. = FALSE)
+  }
+
+  "!DEBUG cache exists: `path`"
+
+  # Protect cache as much as possible
+  Sys.chmod(path, "0600")
+
+  ## TODO(jennybc): this only looks in exact directory of cache path, not up
+  desc <- file.path(cache_parent, "DESCRIPTION")
+  if (file.exists(desc)) {
+    add_line(
+      file.path(cache_parent, ".Rbuildignore"),
+      paste0("^", gsub("\\.", "\\\\.", path), "$")
+    )
+  }
+  git <- file.path(cache_parent, c(".gitignore", ".git"))
+  if (any(file.exists(git))) {
+    add_line(
+      file.path(cache_parent, ".gitignore"),
+      path
+    )
+  }
+
+  TRUE
+}
+
+# cache_token <- function(token, cache_path) {
+#   if (is.null(cache_path)) return()
+#
+#   tokens <- load_cache(cache_path)
+#   tokens[[token$hash()]] <- token
+#   saveRDS(tokens, cache_path)
+# }
+
+fetch_cached_token <- function(hash, cache_path) {
+  if (is.null(cache_path)) return()
+
+  load_cache(cache_path)[[hash]]
+}
+
+# remove_cached_token <- function(token) {
+#   if (is.null(token$cache_path)) return()
+#
+#   tokens <- load_cache(token$cache_path)
+#   tokens[[token$hash()]] <- NULL
+#   saveRDS(tokens, token$cache_path)
+# }
+
+load_cache <- function(cache_path) {
+  if (!file.exists(cache_path) || file_size(cache_path) == 0) {
+    list()
+  } else {
+    readRDS(cache_path)
+  }
+}
+
+file_size <- function(x) file.info(x, extra_cols = FALSE)$size

--- a/R/oauth-cache.R
+++ b/R/oauth-cache.R
@@ -84,18 +84,39 @@ create_cache <- function(path = gargle_cache_path()) {
   TRUE
 }
 
-# cache_token <- function(token, cache_path) {
-#   if (is.null(cache_path)) return()
-#
-#   tokens <- load_cache(cache_path)
-#   tokens[[token$hash()]] <- token
-#   saveRDS(tokens, cache_path)
-# }
+cache_token <- function(token, cache_path) {
+  "!DEBUG cache_token"
+  if (is.null(cache_path)) return()
+
+  tokens <- load_cache(cache_path)
+  tokens <- insert_token(tokens, token)
+  saveRDS(tokens, cache_path)
+}
+
+insert_token <- function(df, new) {
+  "!DEBUG insert_token"
+  if (length(df) == 0 || nrow(df) == 0) {
+    return(entibble(new))
+  }
+
+  df <- df[df$hash != new$hash(), ]
+  df[nrow(df) + 1, ] <- entibble(new)
+  df
+}
+
+entibble <- function(token) {
+  "!DEBUG entibble"
+  tibble::tibble(
+    hash = token$hash(),
+    token = list(token)
+  )
+}
 
 fetch_cached_token <- function(hash, cache_path) {
   if (is.null(cache_path)) return()
 
-  load_cache(cache_path)[[hash]]
+  tokens <- load_cache(cache_path)
+  tokens$token[[match(hash, tokens$hash)]]
 }
 
 # remove_cached_token <- function(token) {

--- a/R/three-legged-oauth.R
+++ b/R/three-legged-oauth.R
@@ -22,6 +22,9 @@ credentials_user_oauth2 <- function(scopes,
                                     app = gargle_app(),
                                     ...) {
   "!DEBUG trying credentials_user_oauth2"
+  if (missing(scopes)) {
+    scopes <- "email"
+  }
   gargle2.0_token(
     app = app,
     scope = scopes,

--- a/R/utils.R
+++ b/R/utils.R
@@ -6,3 +6,25 @@
 NULL
 
 is_string <- function(x) is.character(x) && length(x) == 1
+
+isFALSE <- function(x) identical(x, FALSE)
+
+is.oauth_app <- function(x) inherits(x, "oauth_app")
+
+is.oauth_endpoint <- function(x) inherits(x, "oauth_endpoint")
+
+add_line <- function(path, line, quiet = FALSE) {
+  if (file.exists(path)) {
+    lines <- readLines(path, warn = FALSE)
+    lines <- lines[lines != ""]
+  } else {
+    lines <- character()
+  }
+
+  if (line %in% lines) return(TRUE)
+  if (!quiet) message("Adding ", line, " to ", path)
+
+  lines <- c(lines, line)
+  writeLines(lines, path)
+  TRUE
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,14 @@
 .onLoad <- function(lib, pkg) {
   cred_funs_set_default()
   debugme::debugme()
+
+  op <- options()
+  op.gargle <- list(
+    gargle.oauth_cache = NA,
+    gargle.oob_default = FALSE
+  )
+  toset <- !(names(op.gargle) %in% names(op))
+  if(any(toset)) options(op.gargle[toset])
+
+  invisible()
 }

--- a/man/gargle2.0_token.Rd
+++ b/man/gargle2.0_token.Rd
@@ -6,8 +6,8 @@
 \usage{
 gargle2.0_token(email = NULL, app = gargle_app(), scope = NULL,
   user_params = NULL, type = NULL,
-  use_oob = getOption("httr_oob_default"), credentials = NULL,
-  cache = getOption("httr_oauth_cache"), ...)
+  use_oob = getOption("gargle.oob_default"), credentials = NULL,
+  cache = getOption("gargle.oauth_cache"), ...)
 }
 \arguments{
 \item{email}{Optional. Allows user to target a specific Google identity. If


### PR DESCRIPTION
WIP to discuss in 1-on-1

  * gargle gets own options, `gargle.oob_default` and `gargle.oauth_cache`, instead of consulting those for httr. Same defaults, though.
  * All the (unexported) caching functions from httr come over, so they can gain new defaults or be modified. Allowed me to eliminate the `:::`s I was tolerating for a while.
  * Default cache path is `~/.R/gargle/gargle-oauth` as opposed to `.httr-oauth` in working directory.
  * Store oauth tokens in a tibble, as opposed to a list. Currently just a formal tweak, as the tibble only has two variables: the usual hash identifier and a list-column of Gargle2.0 objects.
