### PR TITLE
Use a more official OAuth entry point when using service account

### DIFF
--- a/R/service-account.R
+++ b/R/service-account.R
@@ -7,14 +7,13 @@
 #' @export
 credentials_service_account <- function(scopes, path = "", ...) {
   "!DEBUG trying credentials_service account"
-  if (path_ext(path) != "json") {
-    stop_glue("{bt('path')} must have extension {sq('json')}, not {sq(path_ext(path))}.")
-  }
   info <- jsonlite::fromJSON(path)
-  token <- httr::TokenServiceAccount$new(
-    endpoint = NULL,
+  token <- httr::oauth_service_token(
+    ## FIXME: not sure endpoint is truly necessary, but httr thinks it is.
+    ## https://github.com/r-lib/httr/issues/576
+    endpoint = gargle_outh_endpoint(),
     secrets = info,
-    params = list(scope = scopes)
+    scope = scopes
   )
   if (is.null(token$credentials$access_token) ||
     !nzchar(token$credentials$access_token)) {


### PR DESCRIPTION
The workaround referenced here:
https://github.com/r-lib/httr/issues/576

My review requests are just an FYI. I'll probably merge and move on.

---

By calling `httr::oauth_service_token()` instead of `httr::TokenServiceAccount$new()`, we get some necessary processing of scopes. The downside is we have to pass an actual OAuth endpoint to satisfy httr, but 🤷‍♀️ seems pretty harmless.

I remove the check for a file extension of `.json` because `jsonlite::fromJSON()` is more flexible than this assumes and can read from "a JSON string, URL or file". The ability to read from a JSON string is actually exploited in @hadley's symmetric encryption approach in bigrquery re: securing a service account token for local and CI use.

`credentials_service_account()` will generally get called within a `tryCatch()` because of the way `token_fetch()` works. So if we barf on non-JSON, we'll simply fall silently through to browser flow. If someone really wants to load a service token and can't, they can call this function directly in their troubleshooting and see any errors directly.