### PR TITLE
Convenience method for creating srcrefs

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -64,3 +64,12 @@ add_email_scope <- function(scopes = NULL) {
   url <- "https://www.googleapis.com/auth/userinfo.email"
   union(scopes %||% character(), url)
 }
+
+new_srcref <- function(lines) {
+  n <- length(lines)
+
+  srcref(
+    srcfilecopy("HIDDEN", lines),
+    c(1L, 1L, n, nchar(lines[[n]]))
+  )
+}


### PR DESCRIPTION
To be used as follows:

```R
fun <- function() "Hello"
attr(fun, "srcref") <- new_srcref(
  "The source code of this function is concealed"
)

fun
#> The source code of this function is concealed
```

I don't have a great sense of what text we should use; we should probably emphasise that the contents of the function are for internal use only.