### PR TITLE
Save tokens in RDS version 2 format

### DIFF
--- a/R/oauth-cache.R
+++ b/R/oauth-cache.R
@@ -148,7 +148,7 @@ token_into_cache <- function(candidate) {
   if (is.null(cache_path)) {
     return()
   }
-  saveRDS(candidate, path(cache_path, candidate$hash()))
+  saveRDS(candidate, path(cache_path, candidate$hash()), version = 2)
 }
 
 # helpers to compare tokens based on SHORTHASH_EMAIL ------------------------


### PR DESCRIPTION
So they can be loaded in R versions prior to 3.6