### PR TITLE
Fix default application credentials path

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # gargle (development version)
 
+* The application default credentials path is fixed on non-Windows platforms
+  (#115, @acroz).
+
 * `response_process()` explicitly declares the UTF-8 encoding of the content in Google API responses [tidyverse/googlesheets4#26](https://github.com/tidyverse/googlesheets4/issues/26).
 
 # gargle 0.4.0

--- a/R/credentials_app_default.R
+++ b/R/credentials_app_default.R
@@ -93,7 +93,7 @@ credentials_app_default_path <- function() {
     appdata <- Sys.getenv("APPDATA", Sys.getenv("SystemDrive", "C:"))
     pth <- c(appdata, "gcloud", pth)
   } else {
-    pth <- path_home(".config", "gcloud")
+    pth <- path_home(".config", "gcloud", pth)
   }
   path_join(pth)
 }

--- a/tests/testthat/test-credentials-app-default.R
+++ b/tests/testthat/test-credentials-app-default.R
@@ -1,0 +1,42 @@
+test_that("credentials_app_default_path() returns the default application credentials path on non-Windows",
+  with_mock(
+    is_windows = function() FALSE,
+    expect_equal(
+      credentials_app_default_path(),
+      path_home(".config", "gcloud", "application_default_credentials.json")
+   )
+  )
+)
+
+test_that("credentials_app_default_path() returns the default application credentials path on Windows",
+  with_mock(
+    is_windows = function() TRUE,
+    expect_equal(
+      credentials_app_default_path(),
+      path_join(c("C:", "gcloud", "application_default_credentials.json"))
+   )
+  )
+)
+
+test_that("credentials_app_default_path() uses the CLOUDSDK_CONFIG environment variable", {
+  config_path <- path_join(c("config", "path"))
+  with_mock(
+    Sys.getenv = function(key) {
+      if (key == "CLOUDSDK_CONFIG") config_path else ""
+    },
+    expect_equal(
+      credentials_app_default_path(),
+      path_join(c(config_path, "application_default_credentials.json"))
+    )
+  )
+})
+
+test_that("credentials_app_default_path() uses the GOOGLE_APPLICATION_CREDENTIALS environment variable", {
+  credentials_path <- path_join(c("path", "to", "credentials.json"))
+  with_mock(
+    Sys.getenv = function(key) {
+      if (key == "GOOGLE_APPLICATION_CREDENTIALS") credentials_path else ""
+    },
+    expect_equal(credentials_app_default_path(), credentials_path)
+  )
+})

--- a/tests/testthat/test-credentials-app-default.R
+++ b/tests/testthat/test-credentials-app-default.R
@@ -1,6 +1,6 @@
 test_that("credentials_app_default_path() returns the default application credentials path on non-Windows",
   with_mock(
-    is_windows = function() FALSE,
+    `gargle::is_windows` = function() FALSE,
     expect_equal(
       credentials_app_default_path(),
       path_home(".config", "gcloud", "application_default_credentials.json")
@@ -10,7 +10,7 @@ test_that("credentials_app_default_path() returns the default application creden
 
 test_that("credentials_app_default_path() returns the default application credentials path on Windows",
   with_mock(
-    is_windows = function() TRUE,
+    `gargle::is_windows` = function() TRUE,
     expect_equal(
       credentials_app_default_path(),
       path_join(c("C:", "gcloud", "application_default_credentials.json"))

--- a/tests/testthat/test-credentials_app_default.R
+++ b/tests/testthat/test-credentials_app_default.R
@@ -1,11 +1,11 @@
 test_that("credentials_app_default_path() returns the default application credentials path on non-Windows",
-  with_mock(
-    `gargle::is_windows` = function() FALSE,
-    expect_equal(
-      credentials_app_default_path(),
-      path_home(".config", "gcloud", "application_default_credentials.json")
-   )
-  )
+          with_mock(
+            `gargle::is_windows` = function() FALSE,
+            expect_equal(
+              credentials_app_default_path(),
+              path_home(".config", "gcloud", "application_default_credentials.json")
+            )
+          )
 )
 
 test_that("credentials_app_default_path() returns the default application credentials path on Windows", {


### PR DESCRIPTION
Prior to this PR, the default credentials path on non-Windows systems was determined to be:

```
~/.config/gcloud
```

rather than the correct:

```
~/.config/gcloud/applicaiton_default_credentials.json
```

This PR fixes this and adds some tests for the logic in the offending function.

This PR fixes #115, and I have validated that the change corrects the issue I had when using `bigrquery` with application default credentials.