### PR TITLE
Look for oauth info in `web` key in client_secret.json

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # gargle (development version)
 
+* `oauth_app_from_json` now supports JSON files from the "Web application"
+  client type. (#155)
+
 # gargle 0.5.0
 
 * [Troubleshooting gargle auth](https://gargle.r-lib.org/articles/troubleshooting.html)

--- a/R/oauth-app.R
+++ b/R/oauth-app.R
@@ -21,7 +21,12 @@ oauth_app_from_json <- function(path,
                                 appname = NULL) {
   stopifnot(is_string(path), is.null(appname) || is_string(appname))
 
-  info <- jsonlite::fromJSON(path, simplifyVector = FALSE)[["installed"]]
+  json <- jsonlite::fromJSON(path, simplifyVector = FALSE)
+  info <- json[["installed"]]
+  if (is.null(info)) {
+    # Web client credentials use this key instead
+    info <- json[["web"]]
+  }
 
   if (!all(c("client_id", "client_secret") %in% names(info))) {
     stop("Can't find 'client_id' and 'client_secret' in the JSON", call. = FALSE)

--- a/R/oauth-app.R
+++ b/R/oauth-app.R
@@ -22,11 +22,7 @@ oauth_app_from_json <- function(path,
   stopifnot(is_string(path), is.null(appname) || is_string(appname))
 
   json <- jsonlite::fromJSON(path, simplifyVector = FALSE)
-  info <- json[["installed"]]
-  if (is.null(info)) {
-    # Web client credentials use this key instead
-    info <- json[["web"]]
-  }
+  info <- json[["installed"]] %||% json[["web"]]
 
   if (!all(c("client_id", "client_secret") %in% names(info))) {
     stop("Can't find 'client_id' and 'client_secret' in the JSON", call. = FALSE)

--- a/tests/testthat/fixtures/client_secret_456.googleusercontent.com.json
+++ b/tests/testthat/fixtures/client_secret_456.googleusercontent.com.json
@@ -1,0 +1,1 @@
+{"web":{"client_id":"abc.apps.googleusercontent.com","project_id":"a_project","auth_uri":"https://accounts.google.com/o/oauth2/auth","token_uri":"https://accounts.google.com/o/oauth2/token","auth_provider_x509_cert_url":"https://www.googleapis.com/oauth2/v1/certs","client_secret":"ssshh-i-am-a-secret","redirect_uris":["urn:ietf:wg:oauth:2.0:oob","http://localhost"]}}

--- a/tests/testthat/test-oauth-app.R
+++ b/tests/testthat/test-oauth-app.R
@@ -8,6 +8,16 @@ test_that("oauth app from JSON", {
   expect_identical(oa$appname, "a_project")
   expect_identical(oa$secret, "ssshh-i-am-a-secret")
   expect_identical(oa$key, "abc.apps.googleusercontent.com")
+
+  oa <- oauth_app_from_json(
+    test_path(
+      "fixtures", "client_secret_456.googleusercontent.com.json"
+    )
+  )
+  expect_s3_class(oa, "oauth_app")
+  expect_identical(oa$appname, "a_project")
+  expect_identical(oa$secret, "ssshh-i-am-a-secret")
+  expect_identical(oa$key, "abc.apps.googleusercontent.com")
 })
 
 test_that("JSON that is apparently not an oauth app triggers error", {


### PR DESCRIPTION
Closes #94

To repro, create a new OAuth client ID, and for "Application type", choose "web". If you download the secrets JSON file for this, you'll see that the key is called `"web"` instead of `"installed"`.