### PR TITLE
Drop proactive scope validation in credentials_gce.

### DIFF
--- a/R/credentials_gce.R
+++ b/R/credentials_gce.R
@@ -17,18 +17,7 @@
 credentials_gce <- function(scopes = "https://www.googleapis.com/auth/cloud-platform",
                             service_account = "default", ...) {
   gargle_debug("trying {.fun credentials_gce}")
-  if (!detect_gce() || is.null(scopes)) {
-    return(NULL)
-  }
-  instance_scopes <- get_instance_scopes(service_account = service_account)
-  # We add a special case for the cloud-platform -> bigquery scope implication.
-  if ("https://www.googleapis.com/auth/cloud-platform" %in% instance_scopes) {
-    instance_scopes <- c(
-      "https://www.googleapis.com/auth/bigquery",
-      instance_scopes
-    )
-  }
-  if (!all(scopes %in% instance_scopes)) {
+  if (!detect_gce()) {
     return(NULL)
   }
 
@@ -149,13 +138,6 @@ list_service_accounts <- function() {
   accounts <- gce_metadata_request("instance/service-accounts")
   ct <- httr::content(accounts, as = "text", encoding = "UTF-8")
   strsplit(ct, split = "/\n", fixed = TRUE)[[1]]
-}
-
-get_instance_scopes <- function(service_account) {
-  path <- glue("instance/service-accounts/{service_account}/scopes")
-  scopes <- gce_metadata_request(path)
-  ct <- httr::content(scopes, as = "text", encoding = "UTF-8")
-  strsplit(ct, split = "\n", fixed = TRUE)[[1]]
 }
 
 # TODO: why isn't scopes used here at all?


### PR DESCRIPTION
Why? Avoid confusion like #161.

When adding support for fetching credentials on a GCE VM, I had originally
added a "guard rail": if the user was requesting scope(s) which weren't
included in the list of scopes the service account was granted, I'd return
`NULL`, letting the credential fetch fall back to another method (eg user
creds).

However, this can lead to confusion: most Google API calls are willing to
accept various scopes, and some scopes imply other scopes (eg an API asking
for a BQ scope will happily accept the cloud-platform scope).

This change removes any scope validation in credentials_gce. On the upside, it
should make it easier for users to use gargle from a GCE VM that *has* the
required scopes. Unfortunately, it does allow one new bit of confusion: a user
invoking gargle on a GCE VM *without* the scopes needed for an API would
previously fall through to fetching user creds; they'll now need to do so
explicitly.

Fixes #161.