### PR TITLE
Update auth URIs and use ours (vs httr's) when refreshing ADC creds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # gargle (development version)
 
+We have switched to newer oauth2.googleapis.com-based OAuth2 URIs, moving away from the accounts.google.com and googleapis.com/oauth2 equivalents.
+
 `credentials_gce()` no longer validates the requested scopes against instance scopes.
 In practice, it's easy for this check to be more of a nuisance than a help (#161, #185 @craigcitro).
 

--- a/R/credentials_app_default.R
+++ b/R/credentials_app_default.R
@@ -71,11 +71,10 @@ credentials_app_default <- function(scopes = NULL, ..., subject = NULL) {
       return(NULL)
     }
     gargle_debug("ADC cred type: {.val authorized_user}")
-    endpoint <- httr::oauth_endpoints("google")
     app <- httr::oauth_app("google", info$client_id, secret = info$client_secret)
     scope <- "https://www.googleapis.com/auth/cloud.platform"
     token <- httr::Token2.0$new(
-        endpoint = endpoint,
+        endpoint = gargle_oauth_endpoint(),
         app = app,
         credentials = list(refresh_token = info$refresh_token),
         # ADC is already cached.

--- a/R/gargle-oauth-endpoint.R
+++ b/R/gargle-oauth-endpoint.R
@@ -9,11 +9,13 @@
 #' @examples
 #' gargle_oauth_endpoint()
 gargle_oauth_endpoint <- function() {
-  httr::oauth_endpoint(
-    base_url = "https://accounts.google.com/o/oauth2",
-    authorize = "auth",
+  out <- httr::oauth_endpoint(
+    base_url = "https://oauth2.googleapis.com",
+    authorize = "",
     access = "token",
-    validate = "https://www.googleapis.com/oauth2/v1/tokeninfo",
+    validate = "tokeninfo",
     revoke = "revoke"
   )
+  out$authorize <- "https://accounts.google.com/o/oauth2/v2/auth"
+  out
 }

--- a/tests/testthat/_snaps/gargle-oauth-endpoint.md
+++ b/tests/testthat/_snaps/gargle-oauth-endpoint.md
@@ -1,0 +1,11 @@
+# gargle_oauth_endpoint() snapshot
+
+    Code
+      gargle_oauth_endpoint()
+    Output
+      <oauth_endpoint>
+       authorize: https://accounts.google.com/o/oauth2/v2/auth
+       access:    https://oauth2.googleapis.com/token
+       validate:  https://oauth2.googleapis.com/tokeninfo
+       revoke:    https://oauth2.googleapis.com/revoke
+

--- a/tests/testthat/test-gargle-oauth-endpoint.R
+++ b/tests/testthat/test-gargle-oauth-endpoint.R
@@ -1,0 +1,3 @@
+test_that("gargle_oauth_endpoint() snapshot", {
+  expect_snapshot(gargle_oauth_endpoint())
+})


### PR DESCRIPTION
Fixes #147, closes #180

`credentials_app_default()` should have always been using `gargle_oauth_endpoint()`, at least once `gargle_oauth_endpoint()` was created.

And it's pretty clear that httr's google endpoint URIs are out of date.

See:

https://github.com/googleapis/oauth2client/issues/742

https://developers.google.com/identity/protocols/oauth2/native-app#step-2:-send-a-request-to-googles-oauth-2.0-server

https://developers.google.com/identity/protocols/oauth2/native-app#exchange-authorization-code

https://developers.google.com/identity/protocols/oauth2/native-app#tokenrevoke

https://developers.google.com/identity/protocols/oauth2/service-account#authorizingrequests