### PR TITLE
Fix authorized_user ADC without explicit scopes.

### DIFF
--- a/R/credentials_app_default.R
+++ b/R/credentials_app_default.R
@@ -67,7 +67,7 @@ credentials_app_default <- function(scopes = NULL, ..., subject = NULL) {
       "https://www.googleapis.com/auth/cloud-platform",
       "https://www.googleapis.com/auth/cloud-platform.readonly"
     )
-    if (is.null(scopes) || !all(scopes %in% valid_scopes)) {
+    if (!is.null(scopes) && !all(scopes %in% valid_scopes)) {
       return(NULL)
     }
     gargle_debug("ADC cred type: {.val authorized_user}")


### PR DESCRIPTION
Fix a bug where if no scopes are passed in, application default credentials fail in the authorized_user flow.

```
>>> credentials_app_default()
NULL
>>> credentials_app_default(scopes=c("https://www.googleapis.com/auth/cloud-platform"))
<Token>
```