### PR TITLE
Consult an env var to detect RStudio Server / Workbench

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,6 @@ Imports:
     openssl,
     rappdirs,
     rlang (>= 1.0.0),
-    rstudioapi,
     stats,
     utils,
     withr

--- a/R/utils.R
+++ b/R/utils.R
@@ -19,11 +19,7 @@ is.oauth_app <- function(x) inherits(x, "oauth_app")
 is.oauth_endpoint <- function(x) inherits(x, "oauth_endpoint")
 
 is_rstudio_server <- function() {
-  if (rstudioapi::hasFun("versionInfo")) {
-    rstudioapi::versionInfo()$mode == "server"
-  } else {
-    FALSE
-  }
+  Sys.getenv("RSTUDIO") == "1")
 }
 
 add_line <- function(path, line) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -19,7 +19,7 @@ is.oauth_app <- function(x) inherits(x, "oauth_app")
 is.oauth_endpoint <- function(x) inherits(x, "oauth_endpoint")
 
 is_rstudio_server <- function() {
-  Sys.getenv("RSTUDIO") == "1")
+  Sys.getenv("RSTUDIO") == "1"
 }
 
 add_line <- function(path, line) {


### PR DESCRIPTION
Motivation is to correctly detect that we're on Workbench even from an R session running inside a terminal.

The approach that uses rstudioapi doesn't work inside such subprocesses.