### PR TITLE
Add default scope to default credentials.

### DIFF
--- a/R/credentials_app_default.R
+++ b/R/credentials_app_default.R
@@ -45,7 +45,8 @@
 #' \dontrun{
 #' credentials_app_default()
 #' }
-credentials_app_default <- function(scopes = NULL, ..., subject = NULL) {
+credentials_app_default <- function(scopes =
+                                      c("https://www.googleapis.com/auth/cloud-platform"), ..., subject = NULL) {
   gargle_debug("trying {.fun credentials_app_default}")
   # In general, application default credentials only include the cloud-platform
   # scope.


### PR DESCRIPTION
Replaces #229.

This fixes a bug where if no scopes are passed in, application default credentials fail in the authorized_user flow.

```
>>> credentials_app_default()
NULL
>>> credentials_app_default(scopes=c("https://www.googleapis.com/auth/cloud-platform"))
<Token>
```