### PR TITLE
Suggest R6 for build-time dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,7 @@ Imports:
     utils,
     withr
 Suggests: 
+    R6,
     aws.ec2metadata,
     aws.signature,
     covr,


### PR DESCRIPTION
R doesn't have any "proper"/"canonical" way to declare a build-time dependency, but I still think it's better to do so:

https://github.com/r-lib/gargle/blob/e9a2d8851694556f9f5cb58e30af14c4ad4858df/R/Gargle-class.R#L148