### PR TITLE
app argument deprecated

### DIFF
--- a/vignettes/get-api-credentials.Rmd
+++ b/vignettes/get-api-credentials.Rmd
@@ -133,7 +133,7 @@ google_client <- gargle::gargle_oauth_client_from_json(
   path = "/path/to/the/JSON/that/was/downloaded/from/gcp/console.json",
   name = "acme-corp-google-client"
 )
-drive_auth_configure(app = google_client)
+drive_auth_configure(client = google_client)
 
 # now any new OAuth tokens are obtained with the configured client
 ```


### PR DESCRIPTION
argument `app` is deprecated in googledrive, and now should be `client` in stead.

