### PR TITLE
Add a necessary minimum version to lifecycle

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     glue (>= 1.3.0),
     httr (>= 1.4.5),
     jsonlite,
-    lifecycle,
+    lifecycle (>= 0.2.0),
     openssl,
     rappdirs,
     rlang (>= 1.1.0),


### PR DESCRIPTION
Fixes https://github.com/r-lib/gargle/issues/283.

This is a niche failure, but also a very easy fix.