### PR TITLE
convert vignette rmd code chunks to plain R chunks to prevent eval

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -46,13 +46,13 @@ See the [articles](https://gargle.r-lib.org/articles/) for holistic advice on ho
 
 You can install the released version of gargle from [CRAN](https://CRAN.R-project.org) with:
 
-```r
+```{r eval = FALSE}
 install.packages("gargle")
 ```
 
 And the development version from [GitHub](https://github.com/) with:
 
-```r
+```{r eval = FALSE}
 # install.packages("pak")
 pak::pak("r-lib/gargle")
 ```
@@ -61,7 +61,7 @@ pak::pak("r-lib/gargle")
 gargle is a low-level package and does not do anything visibly exciting on its own.
 But here's a bit of usage in an interactive scenario where a user confirms they want to use a specific Google identity and loads an OAuth2 token.
 
-```r
+```{r eval = FALSE}
 library(gargle)
 
 token <- token_fetch()

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ out <- response_process(resp)
 
 out <- out[["items"]][1:8]
 sort(vapply(out, function(x) x[["family"]], character(1)))
-#> [1] "Inter"          "Lato"           "Material Icons" "Montserrat"
+#> [1] "Inter"          "Lato"           "Material Icons" "Montserrat"    
 #> [5] "Noto Sans JP"   "Open Sans"      "Poppins"        "Roboto"
 ```
 


### PR DESCRIPTION
Closes #301.

I ran find-replace on the following:

````
```{r eval = FALSE}
```{r, eval = FALSE}
```{r} # where a setup chunk set eval = FALSE at the top
````
and replaced with
````
```r
````
which converts it to plain syntax-highlighted markdown rather than an executable code chunk. This should hopefully prevent evaluation of vignette code that is not meant to be executed