### PR TITLE
Add "Supported By Posit" badge to gargle website

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -9,6 +9,7 @@ template:
 
   includes:
     in_header: |
+      <script src="https://cdn.jsdelivr.net/gh/posit-dev/supported-by-posit/js/badge.min.js" data-max-height="43" data-light-bg="#666f76" data-light-fg="#f9f9f9"></script>
       <script defer data-domain="gargle.r-lib.org,all.tidyverse.org" src="https://plausible.io/js/plausible.js"></script>
 
 news:
@@ -19,61 +20,61 @@ news:
     href: https://www.tidyverse.org/blog/2019/08/gargle-hello-world/
 
 reference:
-  - title: "Fetching credentials"
-    desc: >
-      Load an existing token or obtain a new one
-    contents:
-      - token_fetch
-      - starts_with("credentials")
-      - gargle_oauth_sitrep
-      - starts_with("cred_funs")
-      - starts_with("gargle_oauth_client")
-      - starts_with("token")
-      - gce_instance_service_accounts
-      - gargle_secret
-  - title: "Requests and responses"
-    desc: >
-      Helpers for forming HTTP requests and processing the response
-    contents:
-      - starts_with("request")
-      - starts_with("response")
-      - field_mask
-  - title: "Classes"
-    desc: >
-      Classes to represent a token or auth state and their constructors
-    contents:
-      - Gargle2.0
-      - gargle2.0_token
-      - AuthState
-      - init_AuthState
-  - title: "Options"
-    contents:
-      - gargle_options
-  - title: "Demo assets"
-    desc: >
-      Assets to aid experimentation during development (not for production use!)
-    contents:
-      - gargle_api_key
+- title: "Fetching credentials"
+  desc: >
+    Load an existing token or obtain a new one
+  contents:
+  - token_fetch
+  - starts_with("credentials")
+  - gargle_oauth_sitrep
+  - starts_with("cred_funs")
+  - starts_with("gargle_oauth_client")
+  - starts_with("token")
+  - gce_instance_service_accounts
+  - gargle_secret
+- title: "Requests and responses"
+  desc: >
+    Helpers for forming HTTP requests and processing the response
+  contents:
+  - starts_with("request")
+  - starts_with("response")
+  - field_mask
+- title: "Classes"
+  desc: >
+    Classes to represent a token or auth state and their constructors
+  contents:
+  - Gargle2.0
+  - gargle2.0_token
+  - AuthState
+  - init_AuthState
+- title: "Options"
+  contents:
+  - gargle_options
+- title: "Demo assets"
+  desc: >
+    Assets to aid experimentation during development (not for production use!)
+  contents:
+  - gargle_api_key
 
 articles:
-  - title: For users of packages that use gargle for auth
-    navbar: ~
-    contents:
-    - non-interactive-auth
-    - troubleshooting
-    - auth-from-web
-    - get-api-credentials
+- title: For users of packages that use gargle for auth
+  navbar:
+  contents:
+  - non-interactive-auth
+  - troubleshooting
+  - auth-from-web
+  - get-api-credentials
 
-  - title: For package developers and advanced users
-    contents:
-    - how-gargle-gets-tokens
-    - gargle-auth-in-client-package
-    - oauth-client-not-app
-    - articles/managing-tokens-securely
-    - request-helper-functions
+- title: For package developers and advanced users
+  contents:
+  - how-gargle-gets-tokens
+  - gargle-auth-in-client-package
+  - oauth-client-not-app
+  - articles/managing-tokens-securely
+  - request-helper-functions
 
-  - title: Gargle development
-    desc: Internal development notes
-    contents:
-    - articles/google-compute-engine
+- title: Gargle development
+  desc: Internal development notes
+  contents:
+  - articles/google-compute-engine
 


### PR DESCRIPTION
## Overview

This PR adds the "Supported by Posit" badge to the gargle website.

## Background

We've recently started adding a "Supported by Posit" badge across all Posit package websites to create a more cohesive brand presence. The badge appears on the far right of the top navigation bar or at the bottom of the hamburger menu. It links to Posit’s main website. @hadley is involved with this initiative.

The following websites already have the "Supported by Posit" badge: [ggplot2](https://ggplot2.tidyverse.org), [Great Tables](https://posit-dev.github.io/great-tables/articles/intro.html), [gt](https://gt.rstudio.com), [Plotnine](https://plotnine.org), [Pointblank](https://posit-dev.github.io/pointblank/), [pointblank](https://rstudio.github.io/pointblank/), and [Quarto](https://quarto.org).

See https://posit-dev.github.io/supported-by-posit/ for more information.

## Changes

- Added a line to `_pkgdown.yml` to include the JavaScript file
- Standardized indentation in `_pkgdown.yml`

## Screenshots

At 1200px browser width:

![Screenshot of gargle website at 1200px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/gargle-1200.png)

At 992px browser width:

![Screenshot of gargle website at 992px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/gargle-992.png)

At 991px browser width:

![Screenshot of gargle website at 991px browser width](https://posit-dev.github.io/supported-by-posit/screenshots/gargle-991.png)

