### PR TITLE
Support impersonated ADC credentials

### DIFF
--- a/R/credentials_app_default.R
+++ b/R/credentials_app_default.R
@@ -240,7 +240,7 @@ fetch_impersonated_service_account_access_token <- function(
   req <- list(
     method = "POST",
     url = impersonation_url,
-    body = rlang::compact(list(
+    body = compact(list(
       scope = scope,
       delegates = delegates
     )),

--- a/R/credentials_app_default.R
+++ b/R/credentials_app_default.R
@@ -23,10 +23,11 @@
 #' ```
 
 #' If the above search successfully identifies a JSON file, it is parsed and
-#' ingested as a service account, an external account ("workload identity
-#' federation"), or a user account. Literally, if the JSON describes a service
-#' account, we call [credentials_service_account()] and if it describes an
-#' external account, we call [credentials_external_account()].
+#' ingested as a service account, an impersonated service account, an external
+#' account ("workload identity federation"), or a user account. Literally, if
+#' the JSON describes a service account, we call [credentials_service_account()]
+#' and if it describes an external account, we call
+#' [credentials_external_account()].
 #'
 #' @inheritParams credentials_service_account
 #'
@@ -36,8 +37,9 @@
 
 #' * <https://docs.cloud.google.com/sdk/docs>
 
-#' @return An [`httr::TokenServiceAccount`][httr::Token-class], a [`WifToken`],
-#'   an [`httr::Token2.0`][httr::Token-class] or `NULL`.
+#' @return An [`httr::TokenServiceAccount`][httr::Token-class], an impersonated
+#'   service account token, a [`WifToken`], an
+#'   [`httr::Token2.0`][httr::Token-class] or `NULL`.
 
 #' @family credential functions
 #' @export
@@ -71,29 +73,194 @@ credentials_app_default <- function(scopes = NULL, ..., subject = NULL) {
       return(NULL)
     }
     gargle_debug("ADC cred type: {.val authorized_user}")
-    app <- httr::oauth_app(
-      "google",
-      info$client_id,
-      secret = info$client_secret
+    app_default_authorized_user_token(
+      info,
+      scope = "https://www.googleapis.com/auth/cloud.platform"
     )
-    scope <- "https://www.googleapis.com/auth/cloud.platform"
-    token <- httr::Token2.0$new(
-      endpoint = gargle_oauth_endpoint(),
-      app = app,
-      credentials = list(refresh_token = info$refresh_token),
-      # ADC is already cached.
-      cache_path = FALSE,
-      params = list(scope = scope, as_header = TRUE)
-    )
-    token$refresh()
-    token
   } else if (info$type == "service_account") {
     gargle_debug("ADC cred type: {.val service_account}")
     credentials_service_account(scopes, path = path, subject = subject)
   } else if (info$type == "external_account") {
     gargle_debug("ADC cred type: {.val external_account}")
     credentials_external_account(scopes, path = path)
+  } else if (info$type == "impersonated_service_account") {
+    gargle_debug("ADC cred type: {.val impersonated_service_account}")
+    credentials_impersonated_service_account(scopes, path = path)
+  } else {
+    gargle_debug("ADC cred type is not supported: {.val {info$type}}")
+    NULL
   }
+}
+
+app_default_authorized_user_token <- function(
+  info,
+  scope = "https://www.googleapis.com/auth/cloud.platform"
+) {
+  app <- httr::oauth_app(
+    "google",
+    info$client_id,
+    secret = info$client_secret
+  )
+  token <- httr::Token2.0$new(
+    endpoint = gargle_oauth_endpoint(),
+    app = app,
+    credentials = list(refresh_token = info$refresh_token),
+    # ADC is already cached.
+    cache_path = FALSE,
+    params = list(scope = scope, as_header = TRUE)
+  )
+  token$refresh()
+  token
+}
+
+credentials_impersonated_service_account <- function(
+  scopes = NULL,
+  path = "",
+  ...
+) {
+  if (is.null(scopes)) {
+    scopes <- "https://www.googleapis.com/auth/cloud-platform"
+  }
+  scopes <- normalize_scopes(add_email_scope(scopes))
+
+  token <- oauth_impersonated_service_account(path = path, scopes = scopes)
+
+  if (
+    is.null(token$credentials$access_token) ||
+      !nzchar(token$credentials$access_token)
+  ) {
+    NULL
+  } else {
+    gargle_debug("service account email: {.email {token_email(token)}}")
+    token
+  }
+}
+
+oauth_impersonated_service_account <- function(
+  path = "",
+  scopes = "https://www.googleapis.com/auth/cloud-platform"
+) {
+  info <- jsonlite::fromJSON(path, simplifyVector = FALSE)
+  if (!identical(info[["type"]], "impersonated_service_account")) {
+    gargle_debug(
+      "JSON does not appear to represent an impersonated service account"
+    )
+    return()
+  }
+
+  params <- c(
+    list(scopes = scopes),
+    info,
+    as_header = TRUE
+  )
+  ImpersonatedServiceAccountToken$new(params = params)
+}
+
+ImpersonatedServiceAccountToken <- R6::R6Class(
+  "ImpersonatedServiceAccountToken",
+  inherit = httr::Token2.0,
+  list(
+    initialize = function(params = list()) {
+      gargle_debug("ImpersonatedServiceAccountToken initialize")
+      params$scope <- params$scopes
+      self$params <- params
+
+      self$init_credentials()
+    },
+    init_credentials = function() {
+      gargle_debug("ImpersonatedServiceAccountToken init_credentials")
+      creds <- init_oauth_impersonated_service_account(params = self$params)
+      names(creds) <- google_api_token_snake_case(names(creds))
+      self$credentials <- creds
+      self
+    },
+    refresh = function() {
+      gargle_debug("ImpersonatedServiceAccountToken refresh")
+      self$init_credentials()
+    },
+    format = function(...) {
+      x <- list(
+        scopes = commapse(base_scope(self$params$scope)),
+        credentials = commapse(names(self$credentials))
+      )
+      c(
+        cli::cli_format_method(
+          cli::cli_h1("<ImpersonatedServiceAccountToken (via {.pkg gargle})>")
+        ),
+        glue("{fr(names(x))}: {fl(x)}")
+      )
+    },
+    print = function(...) {
+      cli::cat_line(self$format())
+    },
+    can_refresh = function() {
+      TRUE
+    },
+    cache = function() self,
+    load_from_cache = function() self,
+    validate = function() {},
+    revoke = function() {}
+  )
+)
+
+init_oauth_impersonated_service_account <- function(params) {
+  source_credentials <- params[["source_credentials"]]
+  source_credentials_type <- source_credentials[["type"]]
+
+  if (!identical(source_credentials_type, "authorized_user")) {
+    gargle_abort(
+      c(
+        "Unsupported impersonated service account source credential type.",
+        "i" = "Expected {.val authorized_user}, not {.val {source_credentials_type}}."
+      )
+    )
+  }
+
+  source_token <- app_default_authorized_user_token(
+    source_credentials,
+    scope = "https://www.googleapis.com/auth/cloud-platform"
+  )
+
+  fetch_impersonated_service_account_access_token(
+    source_token = source_token,
+    impersonation_url = normalize_impersonation_url(
+      params[["service_account_impersonation_url"]]
+    ),
+    scope = params[["scope"]],
+    delegates = params[["delegates"]]
+  )
+}
+
+fetch_impersonated_service_account_access_token <- function(
+  source_token,
+  impersonation_url,
+  scope = "https://www.googleapis.com/auth/cloud-platform",
+  delegates = NULL
+) {
+  req <- list(
+    method = "POST",
+    url = impersonation_url,
+    body = rlang::compact(list(
+      scope = scope,
+      delegates = delegates
+    )),
+    token = source_token
+  )
+  resp <- request_make(req)
+  response_process(resp)
+}
+
+normalize_impersonation_url <- function(x) {
+  suffix <- ":generateAccessToken"
+  if (grepl(paste0(suffix, "$"), x)) {
+    x
+  } else {
+    paste0(x, suffix)
+  }
+}
+
+google_api_token_snake_case <- function(x) {
+  gsub("([a-z0-9])([A-Z])", "\\1_\\L\\2", x, perl = TRUE)
 }
 
 credentials_app_default_path <- function() {

--- a/R/token-info.R
+++ b/R/token-info.R
@@ -79,7 +79,17 @@ token_tokeninfo <- function(token) {
   stopifnot(inherits(token, "Token2.0"))
   # I only want to explicitly refresh a user token, which I identify in this
   # rather back-ass-wards way, i.e. by a process of elimination.
-  if (!inherits(token, c("TokenServiceAccount", "WifToken", "GceToken"))) {
+  if (
+    !inherits(
+      token,
+      c(
+        "TokenServiceAccount",
+        "WifToken",
+        "GceToken",
+        "ImpersonatedServiceAccountToken"
+      )
+    )
+  ) {
     # A stale token does not fail in a way that leads to auto refresh.
     # It results in: "Bad Request (HTTP 400)."
     # Hence, the explicit refresh here.

--- a/man/credentials_app_default.Rd
+++ b/man/credentials_app_default.Rd
@@ -29,8 +29,9 @@ scope, so this scope must be enabled for the service account, along with
 any other \code{scopes} being requested.}
 }
 \value{
-An \code{\link[httr:Token-class]{httr::TokenServiceAccount}}, a \code{\link{WifToken}},
-an \code{\link[httr:Token-class]{httr::Token2.0}} or \code{NULL}.
+An \code{\link[httr:Token-class]{httr::TokenServiceAccount}}, an impersonated
+service account token, a \code{\link{WifToken}}, an
+\code{\link[httr:Token-class]{httr::Token2.0}} or \code{NULL}.
 }
 \description{
 Loads credentials from a file identified via a search strategy known as
@@ -51,10 +52,11 @@ CLOUDSDK_CONFIG/application_default_credentials.json
 }\if{html}{\out{</div>}}
 
 If the above search successfully identifies a JSON file, it is parsed and
-ingested as a service account, an external account ("workload identity
-federation"), or a user account. Literally, if the JSON describes a service
-account, we call \code{\link[=credentials_service_account]{credentials_service_account()}} and if it describes an
-external account, we call \code{\link[=credentials_external_account]{credentials_external_account()}}.
+ingested as a service account, an impersonated service account, an external
+account ("workload identity federation"), or a user account. Literally, if
+the JSON describes a service account, we call \code{\link[=credentials_service_account]{credentials_service_account()}}
+and if it describes an external account, we call
+\code{\link[=credentials_external_account]{credentials_external_account()}}.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-credentials_app_default.R
+++ b/tests/testthat/test-credentials_app_default.R
@@ -75,3 +75,205 @@ test_that("credentials_app_default_path(), GOOGLE_APPLICATION_CREDENTIALS env va
     path("GAC", "path")
   )
 })
+
+test_that("credentials_app_default() reports unsupported ADC types", {
+  path <- withr::local_tempfile(fileext = ".json")
+  writeLines(
+    jsonlite::toJSON(
+      list(type = "mystery_credentials"),
+      auto_unbox = TRUE
+    ),
+    path
+  )
+  withr::local_envvar(c(
+    GOOGLE_APPLICATION_CREDENTIALS = path,
+    CLOUDSDK_CONFIG = NA
+  ))
+
+  seen <- character()
+  local_mocked_bindings(
+    gargle_debug = function(text, .envir = parent.frame()) {
+      seen <<- c(
+        seen,
+        vapply(
+          text,
+          function(x) cli::ansi_strip(cli::format_inline(x, .envir = .envir)),
+          character(1)
+        )
+      )
+    }
+  )
+
+  expect_null(credentials_app_default())
+  expect_true(any(grepl(
+    "ADC cred type is not supported",
+    seen,
+    fixed = TRUE
+  )))
+  expect_true(any(grepl("mystery_credentials", seen, fixed = TRUE)))
+})
+
+test_that("credentials_app_default() supports impersonated service accounts", {
+  path <- withr::local_tempfile(fileext = ".json")
+  writeLines(
+    jsonlite::toJSON(
+      list(
+        type = "impersonated_service_account",
+        delegates = list("projects/-/serviceAccounts/delegate@example.com"),
+        service_account_impersonation_url = paste0(
+          "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/",
+          "impersonated@example.com"
+        ),
+        source_credentials = list(
+          type = "authorized_user",
+          client_id = "CLIENT_ID",
+          client_secret = "CLIENT_SECRET",
+          refresh_token = "REFRESH_TOKEN"
+        )
+      ),
+      auto_unbox = TRUE
+    ),
+    path
+  )
+  withr::local_envvar(c(
+    GOOGLE_APPLICATION_CREDENTIALS = path,
+    CLOUDSDK_CONFIG = NA
+  ))
+
+  source_token <- structure(list(source = TRUE), class = "Token2.0")
+  seen <- new.env(parent = emptyenv())
+  local_mocked_bindings(
+    app_default_authorized_user_token = function(info, scope) {
+      seen$source_credentials <- info
+      seen$source_scope <- scope
+      source_token
+    },
+    fetch_impersonated_service_account_access_token = function(
+      source_token,
+      impersonation_url,
+      scope,
+      delegates = NULL
+    ) {
+      seen$source_token <- source_token
+      seen$impersonation_url <- impersonation_url
+      seen$scope <- scope
+      seen$delegates <- delegates
+      list(
+        accessToken = "ACCESS_TOKEN",
+        expireTime = "2026-04-20T12:34:56Z"
+      )
+    }
+  )
+
+  out <- credentials_app_default("https://www.googleapis.com/auth/bigquery")
+
+  expect_true(inherits(out, "ImpersonatedServiceAccountToken"))
+  expect_identical(out$credentials$access_token, "ACCESS_TOKEN")
+  expect_identical(out$credentials$expire_time, "2026-04-20T12:34:56Z")
+  expect_equal(seen$source_credentials$type, "authorized_user")
+  expect_identical(
+    seen$source_scope,
+    "https://www.googleapis.com/auth/cloud-platform"
+  )
+  expect_identical(seen$source_token, source_token)
+  expect_identical(
+    seen$impersonation_url,
+    paste0(
+      "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/",
+      "impersonated@example.com:generateAccessToken"
+    )
+  )
+  expect_equal(
+    seen$scope,
+    c(
+      "https://www.googleapis.com/auth/bigquery",
+      "https://www.googleapis.com/auth/userinfo.email"
+    )
+  )
+  expect_equal(
+    seen$delegates,
+    list("projects/-/serviceAccounts/delegate@example.com")
+  )
+})
+
+test_that("credentials_app_default() defaults impersonated ADC scopes to cloud-platform", {
+  path <- withr::local_tempfile(fileext = ".json")
+  writeLines(
+    jsonlite::toJSON(
+      list(
+        type = "impersonated_service_account",
+        service_account_impersonation_url = paste0(
+          "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/",
+          "impersonated@example.com"
+        ),
+        source_credentials = list(
+          type = "authorized_user",
+          client_id = "CLIENT_ID",
+          client_secret = "CLIENT_SECRET",
+          refresh_token = "REFRESH_TOKEN"
+        )
+      ),
+      auto_unbox = TRUE
+    ),
+    path
+  )
+  withr::local_envvar(c(
+    GOOGLE_APPLICATION_CREDENTIALS = path,
+    CLOUDSDK_CONFIG = NA
+  ))
+
+  seen <- new.env(parent = emptyenv())
+  local_mocked_bindings(
+    app_default_authorized_user_token = function(...) {
+      structure(list(), class = "Token2.0")
+    },
+    fetch_impersonated_service_account_access_token = function(
+      source_token,
+      impersonation_url,
+      scope,
+      delegates = NULL
+    ) {
+      seen$scope <- scope
+      list(
+        accessToken = "ACCESS_TOKEN",
+        expireTime = "2026-04-20T12:34:56Z"
+      )
+    }
+  )
+
+  expect_no_error(credentials_app_default())
+  expect_equal(
+    seen$scope,
+    c(
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/userinfo.email"
+    )
+  )
+})
+
+test_that("credentials_app_default() errors for unsupported impersonation sources", {
+  path <- withr::local_tempfile(fileext = ".json")
+  writeLines(
+    jsonlite::toJSON(
+      list(
+        type = "impersonated_service_account",
+        service_account_impersonation_url = paste0(
+          "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/",
+          "impersonated@example.com:generateAccessToken"
+        ),
+        source_credentials = list(type = "service_account")
+      ),
+      auto_unbox = TRUE
+    ),
+    path
+  )
+  withr::local_envvar(c(
+    GOOGLE_APPLICATION_CREDENTIALS = path,
+    CLOUDSDK_CONFIG = NA
+  ))
+
+  expect_error(
+    credentials_app_default("https://www.googleapis.com/auth/cloud-platform"),
+    "Unsupported impersonated service account source credential type"
+  )
+})

--- a/tests/testthat/test-token-info.R
+++ b/tests/testthat/test-token-info.R
@@ -23,3 +23,26 @@ test_that("token_*() functions work", {
     "https://www.googleapis.com/auth/userinfo.email" %in% tokeninfo$scope
   )
 })
+
+test_that("token_tokeninfo() does not eagerly refresh impersonated service account tokens", {
+  refreshed <- FALSE
+  token <- structure(
+    list(
+      refresh = function() {
+        refreshed <<- TRUE
+      }
+    ),
+    class = c("ImpersonatedServiceAccountToken", "Token2.0", "Token")
+  )
+
+  local_mocked_bindings(
+    request_build = function(...) list(),
+    request_make = function(...) {
+      structure(list(status_code = 200), class = "response")
+    },
+    response_process = function(...) list(scope = character())
+  )
+
+  expect_no_error(token_tokeninfo(token))
+  expect_false(refreshed)
+})


### PR DESCRIPTION
Fixes #266. Adds support for application default credentials with `type = "impersonated_service_account"`.

When `credentials_app_default()` sees this ADC format, gargle now uses the nested `authorized_user` credentials to obtain a source token and exchanges that token against the IAM Credentials API to mint an impersonated access token. It also stops silently falling through for unknown ADC types and emits a debug message instead.

Also updates `token_tokeninfo()` so this token class is treated like the existing nonstandard refreshable token types.

Tests cover the new impersonated ADC flow, default scope behavior, unsupported source credential types, and the unsupported-ADC debug path.